### PR TITLE
Fix #2788

### DIFF
--- a/src/js/actions.ts
+++ b/src/js/actions.ts
@@ -357,6 +357,10 @@ export default class Actions {
       }
       case 1: {
         const other = this.dates.picked[0];
+        if (day.getTime() === other.getTime()) {
+          this.dates.clear();
+          break;
+        }
         if (day.isBefore(other)) {
           this.dates.setValue(day, 0);
           this.dates.setValue(other, 1);


### PR DESCRIPTION
This is a bug fix. If you click two times in the same date when `dateRange` option is `true` the browser crashes.
This fixes this behavior by breaking if current range-start is clicked to prevent an infinite loop.

- [ ] Add a test

